### PR TITLE
Update Avatar image(highlighted:) method to check flag first

### DIFF
--- a/Sources/MessagesDataSource.swift
+++ b/Sources/MessagesDataSource.swift
@@ -47,15 +47,7 @@ public struct Avatar {
     }
 
     public func image(highlighted: Bool) -> UIImage {
-        guard let image = image else {
-            return placeholderImage
-        }
-
-        guard let highlightedImage = highlightedImage else {
-            return image
-        }
-
-        return highlighted ? image : highlightedImage
+        return (highlighted ? highlightedImage : image) ?? placeholderImage
     }
 }
 


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts.
- [X] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/MessageKit/MessageKit/blob/develop/.github/CONTRIBUTING.md). Confirmation: ____

#### This fixes issue #
N/A

## What's in this pull request?
This Pull Request changes the logic for `Avatar`'s `image(highlighted:)` method to check the flag before returning an image.

Currently, the `guard` optional bind statement on the `image` property could cause us to exit the scope before evaluating the `highlightedImage` property when the `highlighted` argument is true.

Since `image` and `highlightedImage` are both optional properties. It's possible to have a `highlightedImage` but not a regular `image`.

Really trivial PR but it stuck out when browsing the source. Why not document it? 😃

Hope to see this project get rolling after the Swift 4 release!!! Would love to contribute.
>...
